### PR TITLE
feat: let agents declare a plan_persona instruction

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -725,6 +725,10 @@
           "$ref": "#/definitions/CacheConfig",
           "description": "Optional response cache: when the same user question is asked again, replay the previous answer instead of calling the model."
         },
+        "plan_persona": {
+          "$ref": "#/definitions/PlanPersonaConfig",
+          "description": "Optional per-mode overrides applied while the session is in plan mode. Plan mode already filters the agent's toolset to read-only tools and injects a per-turn system reminder; plan_persona additionally replaces the agent's instruction for the duration of plan mode so the persona's framing matches its restricted toolset. Useful when the agent's normal instruction is heavily tuned for execution and would conflict with the plan-mode reminder."
+        },
         "skills": {
           "description": "Enable skills discovery for this agent. Set to true to load all discovered skills from local filesystem sources; false disables skills. A list can mix sources (\"local\" or an HTTP/HTTPS URL), skill names to include, and inline skill definitions (objects). If only names are given, local sources are loaded and filtered to just those skills.",
           "oneOf": [
@@ -1012,6 +1016,17 @@
         "path": {
           "type": "string",
           "description": "Path to a JSON file used to persist cache entries across runs. Relative paths are resolved against the agent's config directory. When empty, the cache lives only in memory."
+        }
+      },
+      "additionalProperties": false
+    },
+    "PlanPersonaConfig": {
+      "type": "object",
+      "description": "Per-mode overrides the runtime applies to an agent when the session is in plan mode. Fields are optional; leaving one unset means 'fall back to the agent's normal value'. Plan mode also filters the agent's toolset to read-only tools and prepends a short runtime guardrail so persona authors don't need to repeat the no-edits / no-shell contract.",
+      "properties": {
+        "instruction": {
+          "type": "string",
+          "description": "Replaces the per-turn plan-mode system reminder while plan mode is active. The runtime wraps the value in a <system-reminder> envelope and prefixes a short guardrail line stating that only read-only tools are available, so persona authors own the workflow framing and tone. Empty (or the whole plan_persona block omitted) means 'use the runtime's canned plan-mode reminder unchanged', preserving today's behaviour."
         }
       },
       "additionalProperties": false

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -48,6 +48,10 @@ type Agent struct {
 	harness                 *latest.HarnessConfig
 	hooks                   *latest.HooksConfig
 	cache                   *cache.Cache
+	// planInstruction is the persona instruction used by the runtime
+	// when the session is in plan mode. Empty means "use the runtime's
+	// canned plan-mode reminder". See [latest.PlanPersonaConfig].
+	planInstruction string
 
 	// warningsMu guards pendingWarnings. AddToolWarning and DrainWarnings
 	// may be called concurrently from the runtime loop, the MCP server,
@@ -77,6 +81,13 @@ func (a *Agent) Name() string {
 // Instruction returns the agent's instructions
 func (a *Agent) Instruction() string {
 	return a.instruction
+}
+
+// PlanInstruction returns the persona instruction the runtime uses while
+// the session is in plan mode. Empty means the agent did not declare a
+// plan persona — the runtime falls back to its canned plan-mode reminder.
+func (a *Agent) PlanInstruction() string {
+	return a.planInstruction
 }
 
 func (a *Agent) AddDate() bool {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -563,3 +563,28 @@ func TestAgentToolsRecoversWhenUnderlyingToolsetDies(t *testing.T) {
 	assert.Equal(t, 1, stub.startCalls)
 	assert.Equal(t, 1, stub.restartCalls)
 }
+
+func TestPlanInstruction(t *testing.T) {
+	t.Run("defaults to empty when no persona is configured", func(t *testing.T) {
+		a := New("root", "you are an executor")
+		assert.Empty(t, a.PlanInstruction())
+	})
+
+	t.Run("WithPlanInstruction stores the persona body verbatim", func(t *testing.T) {
+		persona := "You plan. You do not execute."
+		a := New("root", "you are an executor", WithPlanInstruction(persona))
+		assert.Equal(t, persona, a.PlanInstruction())
+		// The agent's normal instruction must remain untouched — the
+		// persona is a per-mode override applied by the runtime, not a
+		// replacement of the canonical instruction.
+		assert.Equal(t, "you are an executor", a.Instruction())
+	})
+
+	t.Run("empty WithPlanInstruction clears any previously stored persona", func(t *testing.T) {
+		a := New("root", "you are an executor",
+			WithPlanInstruction("first"),
+			WithPlanInstruction(""),
+		)
+		assert.Empty(t, a.PlanInstruction())
+	})
+}

--- a/pkg/agent/opts.go
+++ b/pkg/agent/opts.go
@@ -18,6 +18,15 @@ func WithInstruction(instruction string) Opt {
 	}
 }
 
+// WithPlanInstruction sets the persona instruction used by the runtime
+// when the session is in plan mode. An empty string clears the persona
+// so the runtime falls back to its canned plan-mode reminder.
+func WithPlanInstruction(instruction string) Opt {
+	return func(a *Agent) {
+		a.planInstruction = instruction
+	}
+}
+
 func WithToolSets(toolSet ...tools.ToolSet) Opt {
 	var startableToolSet []*tools.StartableToolSet
 	for _, ts := range toolSet {

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -473,6 +473,37 @@ type AgentConfig struct {
 	UseSkills   []string     `json:"use_skills,omitempty"`
 	Hooks       *HooksConfig `json:"hooks,omitempty"`
 	Cache       *CacheConfig `json:"cache,omitempty"`
+
+	// PlanPersona overrides parts of the agent's configuration when the
+	// session is in plan mode. Plan mode (see session.Mode) already filters
+	// the agent's toolset to read-only tools and injects a per-turn system
+	// reminder; PlanPersona lets the agent author additionally replace the
+	// agent's instruction for the duration of plan mode, so the persona's
+	// framing matches its restricted toolset.
+	//
+	// This is useful when the agent's normal instruction is heavily tuned
+	// for execution (e.g. "fix files immediately", "never ask clarifying
+	// questions") and would conflict with the plan-mode reminder otherwise.
+	// Without a PlanPersona the runtime applies the canned reminder on top
+	// of the agent's normal instruction, which leaves the two specs in
+	// tension.
+	PlanPersona *PlanPersonaConfig `json:"plan_persona,omitempty" yaml:"plan_persona,omitempty"`
+}
+
+// PlanPersonaConfig holds the per-mode overrides the runtime applies to an
+// agent when the session is in plan mode. Fields are optional; leaving one
+// empty means "fall back to the agent's normal value".
+type PlanPersonaConfig struct {
+	// Instruction replaces the per-turn plan-mode system reminder while
+	// plan mode is active. The runtime still wraps the value in a
+	// <system-reminder> envelope and prefixes a short guardrail line
+	// stating that only read-only tools are available, so persona authors
+	// don't need to repeat the constraint — they own the workflow framing
+	// and tone.
+	//
+	// Empty (or PlanPersona nil) means "use the runtime's canned plan-mode
+	// reminder unchanged", preserving today's behaviour.
+	Instruction string `json:"instruction,omitempty" yaml:"instruction,omitempty"`
 }
 
 // CacheConfig configures the agent's response cache. When set and Enabled

--- a/pkg/runtime/harness.go
+++ b/pkg/runtime/harness.go
@@ -46,7 +46,7 @@ func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Sessio
 	}()
 
 	turnStartMsgs := r.executeTurnStartHooks(ctx, sess, a, events)
-	planReminder := planModeReminderMessages(sess)
+	planReminder := planModeReminderMessages(sess, a)
 	messages := sess.GetMessages(a, append(append(baseExtra, turnStartMsgs...), planReminder...)...)
 	stop, msg, rewritten := r.executeBeforeLLMCallHooks(ctx, sess, a, modelID, 1, messages)
 	if stop {

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -559,7 +559,7 @@ func (r *LocalRuntime) runTurn(
 	// that GetMessages applies to the last extra). It is appended last so its
 	// instruction is the most recent system context the model sees before the
 	// user prompt — minimising the chance the model ignores it.
-	planReminder := planModeReminderMessages(sess)
+	planReminder := planModeReminderMessages(sess, a)
 	messages := sess.GetMessages(a, slices.Concat(ls.sessionStartMsgs, ls.userPromptMsgs, turnStartMsgs, planReminder)...)
 	slog.DebugContext(ctx, "Retrieved messages for processing", "agent", a.Name(), "message_count", len(messages))
 

--- a/pkg/runtime/plan_mode.go
+++ b/pkg/runtime/plan_mode.go
@@ -1,16 +1,20 @@
 package runtime
 
 import (
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/session"
 )
 
 // planModeReminder is the per-turn system instruction injected when a session
-// is in plan mode. Two layers enforce plan mode: the runtime hides every
-// non-read-only tool from the model (see filterToolsForSession in loop.go),
-// and this reminder tells the model how it should behave. Hiding the tools
-// is the hard guarantee; the reminder is the explanation, so the model
-// produces a useful plan instead of just bouncing off missing tools.
+// is in plan mode and the active agent has not declared a plan persona. Two
+// layers enforce plan mode: the runtime hides every non-read-only tool from
+// the model (see filterToolsForSession in loop.go), and this reminder tells
+// the model how it should behave. Hiding the tools is the hard guarantee; the
+// reminder is the explanation, so the model produces a useful plan instead
+// of just bouncing off missing tools.
 const planModeReminder = `<system-reminder>
 You are currently in PLAN MODE.
 
@@ -31,15 +35,49 @@ to review it. The user will switch you to BUILD MODE when they want execution
 to begin.
 </system-reminder>`
 
+// planPersonaGuardrail is the short preamble the runtime prepends to a
+// declared plan persona. The persona owns the workflow framing and tone; the
+// guardrail owns the read-only contract so persona authors don't have to
+// repeat it (and can't accidentally drop it).
+const planPersonaGuardrail = `You are currently in PLAN MODE. Only read-only tools have been made available to you for this turn; every state-changing tool has been filtered out by the runtime.`
+
 // planModeReminderMessages returns the system-reminder messages to splice
 // before the conversation history when sess is in plan mode. Returns nil for
 // other modes so callers can use it unconditionally.
-func planModeReminderMessages(sess *session.Session) []chat.Message {
+//
+// When the active agent has declared a plan persona (see
+// [latest.PlanPersonaConfig]), the persona's instruction is wrapped in a
+// <system-reminder> envelope and prefixed with [planPersonaGuardrail] so
+// persona authors own the workflow framing while the runtime keeps the
+// read-only contract intact. When no persona is declared, the canned
+// [planModeReminder] is used unchanged — preserving today's behaviour for
+// agents that haven't opted in.
+func planModeReminderMessages(sess *session.Session, a *agent.Agent) []chat.Message {
 	if sess == nil || sess.Mode != session.ModePlan {
 		return nil
 	}
 	return []chat.Message{{
 		Role:    chat.MessageRoleSystem,
-		Content: planModeReminder,
+		Content: planModeReminderContent(a),
 	}}
+}
+
+// planModeReminderContent picks the right reminder body for the active
+// agent: the agent's declared plan persona (wrapped in the runtime's
+// guardrail envelope) when set, otherwise the canned reminder.
+func planModeReminderContent(a *agent.Agent) string {
+	if a == nil {
+		return planModeReminder
+	}
+	persona := strings.TrimSpace(a.PlanInstruction())
+	if persona == "" {
+		return planModeReminder
+	}
+	var b strings.Builder
+	b.WriteString("<system-reminder>\n")
+	b.WriteString(planPersonaGuardrail)
+	b.WriteString("\n\n")
+	b.WriteString(persona)
+	b.WriteString("\n</system-reminder>")
+	return b.String()
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2433,19 +2433,64 @@ func TestFilterToolsForSession_PlanMode(t *testing.T) {
 }
 
 func TestPlanModeReminderMessages(t *testing.T) {
+	canned := agent.New("canned", "you are an executor")
+
 	t.Run("build mode returns nil", func(t *testing.T) {
-		assert.Nil(t, planModeReminderMessages(&session.Session{Mode: session.ModeBuild}))
+		assert.Nil(t, planModeReminderMessages(&session.Session{Mode: session.ModeBuild}, canned))
 	})
 
 	t.Run("nil session returns nil", func(t *testing.T) {
-		assert.Nil(t, planModeReminderMessages(nil))
+		assert.Nil(t, planModeReminderMessages(nil, canned))
 	})
 
-	t.Run("plan mode returns a single system reminder", func(t *testing.T) {
-		msgs := planModeReminderMessages(&session.Session{Mode: session.ModePlan})
+	t.Run("plan mode returns the canned reminder when the agent has no persona", func(t *testing.T) {
+		msgs := planModeReminderMessages(&session.Session{Mode: session.ModePlan}, canned)
 		assert.Len(t, msgs, 1)
 		assert.Equal(t, chat.MessageRoleSystem, msgs[0].Role)
 		assert.Contains(t, msgs[0].Content, "PLAN MODE")
+		// The canned reminder spells out the no-edits / no-shell rules
+		// itself; the persona path doesn't.
+		assert.Contains(t, msgs[0].Content, "No edits to files")
+	})
+
+	t.Run("plan mode uses the agent's persona when set", func(t *testing.T) {
+		personaText := "You are a planning specialist. Ask questions. Write a numbered plan."
+		withPersona := agent.New(
+			"with-persona",
+			"you are an executor",
+			agent.WithPlanInstruction(personaText),
+		)
+		msgs := planModeReminderMessages(&session.Session{Mode: session.ModePlan}, withPersona)
+		require.Len(t, msgs, 1)
+		// Persona body must be present.
+		assert.Contains(t, msgs[0].Content, personaText)
+		// Runtime guardrail must be prepended so persona authors don't
+		// have to (and can't accidentally drop) the read-only contract.
+		assert.Contains(t, msgs[0].Content, "Only read-only tools have been made available")
+		// And the body must live inside a <system-reminder> envelope so
+		// it visually matches the canned path.
+		assert.True(t, strings.HasPrefix(msgs[0].Content, "<system-reminder>"))
+		assert.True(t, strings.HasSuffix(msgs[0].Content, "</system-reminder>"))
+		// The canned no-edits enumeration must NOT leak in — the persona
+		// owns the framing once set.
+		assert.NotContains(t, msgs[0].Content, "No shell commands or background jobs")
+	})
+
+	t.Run("plan mode falls back to canned reminder when persona is whitespace only", func(t *testing.T) {
+		blank := agent.New(
+			"blank-persona",
+			"you are an executor",
+			agent.WithPlanInstruction("   \n\t  "),
+		)
+		msgs := planModeReminderMessages(&session.Session{Mode: session.ModePlan}, blank)
+		require.Len(t, msgs, 1)
+		assert.Contains(t, msgs[0].Content, "No edits to files")
+	})
+
+	t.Run("plan mode tolerates a nil agent", func(t *testing.T) {
+		msgs := planModeReminderMessages(&session.Session{Mode: session.ModePlan}, nil)
+		require.Len(t, msgs, 1)
+		assert.Contains(t, msgs[0].Content, "No edits to files")
 	})
 }
 

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -258,6 +258,10 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 
 		opts = append(opts, agent.WithToolSets(agentTools...))
 
+		if persona := agentConfig.PlanPersona; persona != nil && persona.Instruction != "" {
+			opts = append(opts, agent.WithPlanInstruction(expander.Expand(ctx, persona.Instruction, nil)))
+		}
+
 		ag := agent.New(agentConfig.Name, expander.Expand(ctx, agentConfig.Instruction, nil), opts...)
 		agents = append(agents, ag)
 		agentsByName[agentConfig.Name] = ag

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -327,6 +327,31 @@ func TestToolsetInstructions(t *testing.T) {
 	require.Equal(t, expected, instructions)
 }
 
+// TestPlanPersonaInstruction verifies that agents.<name>.plan_persona.instruction
+// is loaded onto the resulting *agent.Agent so the runtime can pick it up when
+// the session enters plan mode. ${env.X} placeholders are expanded the same way
+// as the canonical instruction.
+func TestPlanPersonaInstruction(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+	t.Setenv("USER", "alice")
+
+	agentSource, err := config.Resolve("testdata/plan-persona.yaml", nil)
+	require.NoError(t, err)
+
+	team, err := Load(t.Context(), agentSource, &config.RuntimeConfig{})
+	require.NoError(t, err)
+
+	rootAgent, err := team.Agent("root")
+	require.NoError(t, err)
+
+	// The canonical (build-mode) instruction must remain unchanged: the
+	// persona is a per-mode override, not a replacement.
+	assert.Equal(t, "You are an executor. Act now.", rootAgent.Instruction())
+
+	// The plan persona must be loaded with ${env.X} placeholders expanded.
+	assert.Equal(t, "Hello alice, you plan. You do not execute.", rootAgent.PlanInstruction())
+}
+
 // TestInstructionExpansion verifies that ${env.X} placeholders are expanded
 // at load time both in agent.instruction and in toolsets[*].instruction.
 // See https://github.com/docker/docker-agent/issues/2614.

--- a/pkg/teamloader/testdata/plan-persona.yaml
+++ b/pkg/teamloader/testdata/plan-persona.yaml
@@ -1,0 +1,6 @@
+agents:
+  root:
+    model: openai/gpt-4o
+    instruction: "You are an executor. Act now."
+    plan_persona:
+      instruction: "Hello ${env.USER}, you plan. You do not execute."


### PR DESCRIPTION
## Why

Plan mode (#3140) is the host-facing primitive: a session flag a host (CLI, TUI, embedder) flips to put the agent into a research-and-draft posture instead of an act-now one. Two layers enforce it: the runtime strips every tool without `Annotations.ReadOnlyHint`, and a per-turn `<system-reminder>` tells the model to plan rather than act.

That works as a host primitive — but it leaves a real prompt conflict when the agent's canonical instruction is heavily tuned for execution. Many real-world coding-agent YAMLs read like the example below:

```yaml
instruction: |
  You are an executor. Fix files immediately. Never ask clarifying
  questions. Tool call discipline before FIRST response. …
```

Layering a "no edits, no shell, no state changes, ask the user" reminder on top of that gives the model two contradictory specs in the same context. Even with the mutating tools hidden, the action-oriented framing leaks into behaviour: the model still pushes to a one-turn conclusion, refuses to iterate, and drops the plan in execution-completion shape. The PR title and the `<system-reminder>` envelope alone aren't enough — the upstream instruction needs to change too.

This PR adds the missing knob without disturbing the host-level primitive: agents can declare a `plan_persona` whose instruction the runtime swaps in for the plan-mode reminder.

## What

```mermaid
flowchart LR
    A[session.Mode = plan] --> B{agent.PlanInstruction set?}
    B -- "no, today's behaviour" --> C["canned plan-mode reminder<br/>(no edits / no shell / etc.)"]
    B -- "yes (new)" --> D["&lt;system-reminder&gt;<br/>guardrail line +<br/>persona instruction"]
    C --> E[GetMessages extras]
    D --> E
```

- `latest.AgentConfig` gains an optional `PlanPersona *PlanPersonaConfig`. The only field today is `instruction`. The block is intentionally minimal so follow-ups can add `model`, `toolsets`, etc. additively without locking the shape.
- `agent.Agent` carries a `planInstruction string` and exposes `PlanInstruction()` / `WithPlanInstruction(...)`. The canonical `Instruction()` is untouched — the persona is a per-mode override, not a replacement.
- `runtime/plan_mode.go`'s `planModeReminderMessages` takes the active agent. When the agent has declared a persona, the runtime wraps it in the existing `<system-reminder>` envelope and prefixes a short guardrail line stating that only read-only tools are available, so persona authors own the workflow framing and tone while the read-only contract stays runtime-owned and impossible for the persona author to drop. When no persona is declared, the canned reminder is used unchanged — preserving today's behaviour for every agent that hasn't opted in.
- `teamloader` expands `${env.X}` placeholders in the persona instruction the same way it does for `Instruction`.
- `agent-schema.json` adds `plan_persona` to the agent properties and a `PlanPersonaConfig` definition.

Example:

```yaml
agents:
  root:
    instruction: |
      You are an executor. Act now. Never ask clarifying questions.
    plan_persona:
      instruction: |
        You plan. You do not execute. Ask clarifying questions and
        iterate with the user. Produce a numbered, file-specific plan.
```

In build mode the agent runs the executor instruction. In plan mode the runtime sees `PlanInstruction()` is non-empty, emits the persona-wrapped reminder, and the executor instruction is no longer the most recent system context — the persona is.

## Scope

In: schema field, runtime swap, teamloader wiring, agent-schema.json entry, unit tests at every layer (agent opt round-trip, runtime reminder selection incl. nil-agent / whitespace-only persona / canned-fallback, end-to-end teamloader YAML→`Agent.PlanInstruction()`).

Out (left to follow-ups):

- `plan_persona.model` for per-mode model overrides.
- `plan_persona.toolsets` for per-mode toolset overrides.
- A plan-file artifact + `plan_exit` tool — orthogonal, on top of this.

## Dependencies

Stacked on #3140 (session-scoped plan/build mode). The new branch is based on that PR's commit; once #3140 lands this can be rebased on `main` and reviewed as a single commit.
